### PR TITLE
Fix pandda2.analyse entry point: console_scripts (fixes uninstalled pandda.py + macOS portability)

### DIFF
--- a/pandda_gemmi/cli.py
+++ b/pandda_gemmi/cli.py
@@ -1,0 +1,29 @@
+"""Console-script entry point for ``pandda2.analyse``.
+
+This lives inside the installed ``pandda_gemmi`` package so it is importable from
+a ``console_scripts`` entry point. That fixes three problems with the previous
+``scripts/pandda2.analyse`` bash wrapper:
+
+* the wrapper referenced ``pandda.py``, which was never installed into ``bin/``;
+* it used ``readlink -f``, which is unsupported by stock BSD ``readlink`` on macOS;
+* it called a bare ``python3.9``, which on macOS resolves to Homebrew's
+  interpreter ahead of the active conda env.
+
+A ``console_scripts`` entry point is installed with the correct interpreter
+shebang automatically and needs no path resolution, fixing all three.
+"""
+
+from pandda_gemmi.args import PanDDAArgs
+from pandda_gemmi.pandda.pandda import pandda
+
+
+def main():
+    # Parse command line arguments
+    args = PanDDAArgs.from_command_line()
+
+    # Process the PanDDA
+    pandda(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ license.file = "LICENSE"
 readme = "README.md"
 requires-python = ">=3.9"
 
+[project.scripts]
+"pandda2.analyse" = "pandda_gemmi.cli:main"
+
 #[project.optional-dependencies]
 #intel = ["scikit-learn-intelex",]
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setuptools.setup(
     install_requires=requirements(),
     scripts=[
         "scripts/pandda_rhofit.sh",
-        "scripts/pandda2.analyse",
     ]
+    # NOTE: ``pandda2.analyse`` is now provided as a console_scripts entry point
+    # in pyproject.toml (pandda_gemmi.cli:main), which installs with the correct
+    # interpreter and needs no path resolution. The old scripts/pandda2.analyse
+    # bash wrapper referenced an uninstalled pandda.py and was not macOS-portable.
 )


### PR DESCRIPTION
## What this fixes

Closes #90.

After a clean `pip install -e .`, the documented `pandda2.analyse` command was broken because the bash wrapper `scripts/pandda2.analyse` referenced `$SCRIPT_DIR/pandda.py`, but `pandda.py` was never listed in `setup.py`'s `scripts=[...]` and so was never installed into `bin/`:

```
$ pandda2.analyse --help
.../bin/python3.9: can't open file '.../bin/pandda.py': [Errno 2] No such file or directory
```

The wrapper was also not macOS-portable:
- `readlink -f` is unsupported by the stock BSD `readlink` on macOS.
- bare `python3.9` resolves to Homebrew's `/opt/homebrew/bin/python3.9` ahead of the active conda env, running in the wrong interpreter.

## The change

Provide `pandda2.analyse` as a `console_scripts` entry point instead of a bash wrapper:

- New `pandda_gemmi/cli.py` with a `main()` (same body as the old `scripts/pandda.py`).
- `[project.scripts]` in `pyproject.toml` maps `pandda2.analyse = pandda_gemmi.cli:main`.
- Removed the broken `scripts/pandda2.analyse` from `setup.py`'s `scripts` list (kept `pandda_rhofit.sh`).

pip generates the launcher with the correct interpreter shebang automatically and needs no path resolution, fixing all three problems. `scripts/pandda.py` is left in place for backwards compatibility.

## Verification

Tested on Apple Silicon (M1 Pro, conda `python=3.9`):

- `pandda2.analyse --help` works (usage line now correctly reads `pandda2.analyse`).
- A run against an empty data dir (`--data_dirs <empty> --out_dir <tmp>`) dispatches into the real pipeline — prints the PanDDA 2 banner and version, summarises parsed args, initialises the Ray processor — and fails only later on absent data (`zero-size array to reduction`), confirming the launcher, package imports and the torch load all work.

Note: this does not change any analysis behaviour — only how the entry point is installed and invoked.

---

Reported & fixed by Martin Noble (martin.noble@ncl.ac.uk), with help from Claude Code.
