### PR TITLE
Fix NameError: import missing serialize module in process_dataset

### DIFF
--- a/pandda_gemmi/pandda/process_dataset.py
+++ b/pandda_gemmi/pandda/process_dataset.py
@@ -47,6 +47,7 @@ from pandda_gemmi.autobuild import AutobuildResult
 from pandda_gemmi.autobuild.inbuilt import mask_dmap, get_conformers, autobuild_conformer
 
 from pandda_gemmi.plots import plot_aligned_density_projection
+from pandda_gemmi import serialize
 
 def read_dataset(fs, dtag):
     pandda_events = {}


### PR DESCRIPTION
## The bug

A real analysis run crashes with:

```
NameError: name 'serialize' is not defined
```

`pandda_gemmi/pandda/process_dataset.py` uses the `serialize` module in three places but never imports it:

- line 58:  `serialize.unserialize_events(...)`
- line 616: `serialize.processed_dataset(...)`
- line 629: `serialize.serialize_events(...)`

These calls are only reached when processing real datasets through to the event-serialization / autobuild stage, so the missing import is latent on `--help` and short smoke tests but fatal on an actual run.

## The fix

Add the import:

```python
from pandda_gemmi import serialize
```

The `pandda_gemmi/serialize` package already exports `unserialize_events`, `processed_dataset` and `serialize_events` from its `__init__.py`, so this one line is sufficient — no other change needed.

## Verification

Hit on a real BAZ2B dataset run (Apple Silicon, conda `python=3.9`). With this import added, the run proceeds past the previously-crashing event-serialization stage.

---

Reported & fixed by Martin Noble (martin.noble@ncl.ac.uk), with help from Claude Code.
