### PR TITLE
Support flat ligand files in the dataset directory (run Zenodo benchmark without copying)

### DIFF
--- a/pandda_gemmi/fs/pandda_input.py
+++ b/pandda_gemmi/fs/pandda_input.py
@@ -153,9 +153,29 @@ def parse_dir_ligands(path: Path, ligand_cif_regex, ligand_smiles_regex, ligand_
 
 
 def get_input_ligands(path: Path, ligand_dir_regex, ligand_cif_regex, ligand_smiles_regex, ligand_pdb_regex, check_input):
-    # path_ligands = parse_dir_ligands(path, ligand_cif_regex, ligand_smiles_regex, ligand_pdb_regex, )
     path_ligands = {}
+
+    # First, look for ligand files directly in the dataset directory (a "flat"
+    # layout, e.g. ligand.cif / ligand.pdb beside the pdb/mtz). This is the
+    # layout used by the published PanDDA benchmark datasets on Zenodo, and
+    # without this a flat dataset is filtered out with "no ligand data!" unless
+    # the ligands are manually moved into a subdirectory.
+    for ligand_key, ligand_files in parse_dir_ligands(
+            path,
+            ligand_cif_regex,
+            ligand_smiles_regex,
+            ligand_pdb_regex,
+            check_input,
+    ).items():
+        path_ligands[ligand_key] = ligand_files
+
+    # Then look inside any subdirectory matching ligand_dir_regex (e.g.
+    # "compound"). Subdirectory ligands take precedence when more complete.
     for ligand_dir_path in path.glob("*"):
+        # Only directories can be ligand subdirectories; skip the flat files
+        # already handled above.
+        if not ligand_dir_path.is_dir():
+            continue
         # print(f"Attempting match of {ligand_dir_path.name} to {ligand_dir_regex}")
         match = re.match(str(ligand_dir_regex), str(ligand_dir_path.name))
         # print(f"Match: {match}")


### PR DESCRIPTION
## The problem

`get_input_ligands` only looks for ligand files inside a *subdirectory* of each dataset directory that matches `ligand_dir_regex` (default `"compound"`). Datasets that store their ligand files **flat** in the dataset directory — e.g. `ligand.cif` / `ligand.pdb` sitting beside the `.pdb`/`.mtz` — are filtered out with:

```
<dtag> : Filtered because no ligand data!
```

This is exactly the layout of the **published PanDDA benchmark datasets on Zenodo** (e.g. BAZ2B). As a result, the reference data cannot be run without first manually copying every dataset's ligand files into a `compound/` subdirectory.

There is no argument value that works around this: in the original code the loop only ever recurses into matched *subdirectories*, and the line that would have scanned the dataset directory itself was present but commented out:

```python
# path_ligands = parse_dir_ligands(path, ligand_cif_regex, ligand_smiles_regex, ligand_pdb_regex, )
```

(Passing `ligand_dir_regex="."` does not help — `path.glob("*")` never yields `.`, and as a regex `.` matches the flat files as if they were directories, which then glob to nothing.)

## The fix

Scan the dataset directory itself for ligand files first (the previously commented-out behaviour), then scan ligand subdirectories as before:

- Flat ligand files seed the result.
- Subdirectory ligands still take precedence when more complete, so existing `compound/`-style layouts are **unchanged**.
- Also skip non-directories in the subdirectory loop. Previously a *file* whose name matched `ligand_dir_regex` would be passed to `parse_dir_ligands`, which silently globbed nothing — harmless but wrong.

This is purely additive: it adds support for the flat layout without changing behaviour for the subdirectory layout.

## Verification

On the BAZ2B Zenodo dataset (Apple Silicon, conda `python=3.9`), calling `get_input_ligands` with **default arguments**:

- **Flat layout** (`ligand.cif`/`ligand.pdb` in the dataset dir, no subdir): now resolves the ligand — previously returned nothing.
- **Subdirectory layout** (`compound/ligand.cif`): continues to resolve correctly — no regression.

---

Reported & fixed by Martin Noble (martin.noble@ncl.ac.uk), with help from Claude Code.
