### PR TITLE
Remove stray debug rprint dumps from the site model

### DIFF
--- a/pandda_gemmi/site_model/site_model.py
+++ b/pandda_gemmi/site_model/site_model.py
@@ -477,11 +477,6 @@ class HeirarchicalSiteModelAlignedSequences:
                 if aligned_dtag == mov_dtag:
                     mov_chain_classes[aligned_chain] = (alignment_dtag, alignment_chain)
 
-        rprint('ref_chain_classes')
-        rprint(ref_chain_classes)
-        rprint('mov_chain_classes')
-        rprint(mov_chain_classes)
-
         # Map residues between the environments
         try:
             ref_aligned_resids = []
@@ -514,11 +509,6 @@ class HeirarchicalSiteModelAlignedSequences:
             rprint(alignment)
             raise Exception
         mov_aligned_resids_set = set(mov_aligned_resids)
-
-        rprint('ref_aligned_resids_set')
-        rprint(ref_aligned_resids_set)
-        rprint('mov_aligned_resids_set')
-        rprint(mov_aligned_resids_set)
 
         union = mov_aligned_resids_set.union(ref_aligned_resids_set)
         intersection = mov_aligned_resids_set.intersection(ref_aligned_resids_set)
@@ -573,18 +563,12 @@ class HeirarchicalSiteModelAlignedSequences:
         
         # Get the sequence alignments
         msa = self.get_alignments(datasets)
-        rprint('Multiple sequence alignment is:')
-        rprint(msa)
 
         # Find the residue environment of each event (chain and residue number)
         event_environments: Dict[Tuple[str, int], List[Tuple[str, str]]] = self.get_event_environments(datasets, events, distance=self.distance)
-        rprint('Event environments are:')
-        rprint(event_environments)
 
         # Get overlaps
         distances = self.get_event_distances(event_environments, msa)
-        rprint('Distances:')
-        rprint(distances)
 
         # Find the site centroids against the reference
         distance_matrix = np.array(
@@ -599,14 +583,10 @@ class HeirarchicalSiteModelAlignedSequences:
 
             ]
         )
-        rprint('Distance matrix is:')
-        rprint(distance_matrix)
 
         event_id_array = np.array(
             [_event_id for _event_id in distances.keys()]
         )
-        rprint('Event id array is:')
-        rprint(event_id_array)
 
         # Cluster the centroids
         linkage = scipy.cluster.hierarchy.linkage(
@@ -627,9 +607,6 @@ class HeirarchicalSiteModelAlignedSequences:
         #     method="complete",
             
         # )
-        rprint('Clusters are:')
-        rprint(clusters)
-
 
         # Get the event sites
         event_sites = {}


### PR DESCRIPTION
## The problem

`HeirarchicalSiteModelAlignedSequences` (in `pandda_gemmi/site_model/site_model.py`) contains a number of **unconditional `rprint(...)` debug statements** that dump large internal structures to stdout during the final site-building stage:

- the full multiple sequence alignment (`msa`)
- every event environment
- the complete event-distance dictionary
- the distance matrix and event-id array
- per-pair `ref_chain_classes` / `mov_chain_classes`
- the `ref_aligned_resids_set` / `mov_aligned_resids_set` for every dataset pair
- the cluster array

On a real run this prints a wall of pretty-printed, JSON-looking output — one block per dataset pair, so hundreds of blocks for a typical screen. It's alarming the first time you see it (it looks like the results are being dumped to the terminal rather than written to file), and it slows the finish with console I/O.

The actual results are written to the `analyses/` CSV tables regardless — this is pure debug noise left over from development.

## The fix

Remove the unconditional debug `rprint` calls (23 lines). The two `rprint` calls inside the `except` blocks of `get_event_distance` are **retained**, since they only fire on an actual alignment error before re-raising and are genuinely diagnostic.

No behavioural change — only console output is affected.

## Verification

Hit during a full BAZ2B run (Apple Silicon, conda `python=3.9`): the site model produced 41 sites correctly while emitting this debug flood. After the change the module imports and the site-building logic is unchanged.

---

Reported & fixed by Martin Noble (martin.noble@ncl.ac.uk), with help from Claude Code.
