### PR TITLE
Resolve ligand restraint block by content, not a guessed TLC

### DIFF
--- a/pandda_gemmi/autobuild/inbuilt.py
+++ b/pandda_gemmi/autobuild/inbuilt.py
@@ -16,6 +16,7 @@ from ..interfaces import *
 from ..fs import try_make
 from ..dmaps import load_dmap, save_dmap, SparseDMap
 from ..dataset.structure import save_structure, load_structure, Structure
+from ..dataset.small import get_comp_block_key
 from .autobuild import AutobuildResult
 
 
@@ -101,11 +102,7 @@ def get_fragment_mol_from_dataset_cif_path(dataset_cif_path: Path):
     mol = Chem.Mol()
     editable_mol = Chem.EditableMol(mol)
 
-    key = "comp_LIG"
-    try:
-        cif['comp_LIG']
-    except:
-        key = "comp_XXX"
+    key = get_comp_block_key(cif)
 
     # Find the relevant atoms loop
     atom_id_loop = list(cif[key].find_loop('_chem_comp_atom.atom_id'))
@@ -262,11 +259,8 @@ def get_structures_from_mol(mol: Chem.Mol, dataset_cif_path, max_conformers):
     cif = gemmi.cif.read(str(dataset_cif_path))
 
     # Find the relevant atoms loop
-    try:
-        atom_id_loop = list(cif['comp_LIG'].find_loop('_chem_comp_atom.atom_id'))
-    # print(f"Atom ID loop: {atom_id_loop}")
-    except:
-        atom_id_loop = list(cif['comp_XXX'].find_loop('_chem_comp_atom.atom_id'))
+    key = get_comp_block_key(cif)
+    atom_id_loop = list(cif[key].find_loop('_chem_comp_atom.atom_id'))
 
     fragment_structures = {}
     for i, conformer in enumerate(mol.GetConformers()):

--- a/pandda_gemmi/dataset/small.py
+++ b/pandda_gemmi/dataset/small.py
@@ -17,6 +17,37 @@ bond_type_cif_to_rdkit = {
 
 }
 
+
+def get_comp_block_key(cif):
+    """Resolve the name of the ligand restraint block in a _chem_comp cif.
+
+    A monomer dictionary contains a "comp_list" header block plus the actual
+    restraint block named "comp_<TLC>" (e.g. comp_LIG, comp_DRG). The
+    three-letter code varies between dictionary generators (acedrg, grade,
+    refmac, ...), so read the block from the document rather than guessing the
+    TLC: return the first block (other than the comp_list header) that contains
+    a _chem_comp_atom loop. Falls back to the historical comp_LIG/comp_XXX
+    guesses for unusual layouts.
+    """
+    for block in cif:
+        if block.name == "comp_list":
+            continue
+        if list(block.find_loop('_chem_comp_atom.atom_id')):
+            return block.name
+
+    for candidate in ("comp_LIG", "comp_XXX"):
+        try:
+            cif[candidate]
+            return candidate
+        except Exception:
+            continue
+
+    raise KeyError(
+        "No _chem_comp restraint block found in cif "
+        f"(blocks present: {[block.name for block in cif]})"
+    )
+
+
 def get_fragment_mol_from_dataset_cif_path(dataset_cif_path: Path):
     # Open the cif document with gemmi
     cif = gemmi.cif.read(str(dataset_cif_path))
@@ -25,11 +56,7 @@ def get_fragment_mol_from_dataset_cif_path(dataset_cif_path: Path):
     mol = Chem.Mol()
     editable_mol = Chem.EditableMol(mol)
 
-    key = "comp_LIG"
-    try:
-        cif['comp_LIG']
-    except:
-        key = "comp_XXX"
+    key = get_comp_block_key(cif)
 
     # Find the relevant atoms loop
     atom_id_loop = list(cif[key].find_loop('_chem_comp_atom.atom_id'))


### PR DESCRIPTION
## Problem

`get_fragment_mol_from_dataset_cif_path` and `get_structures_from_mol` (in `autobuild/inbuilt.py`), and the sibling `get_fragment_mol_from_dataset_cif_path` in `dataset/small.py`, hard-coded the cif data block name to `comp_LIG`, falling back to `comp_XXX`:

```python
key = "comp_LIG"
try:
    cif['comp_LIG']
except:
    key = "comp_XXX"
```

A monomer dictionary's restraint block is named `comp_<TLC>`, where the three-letter code depends on the dictionary generator (acedrg/grade often default to `DRG`). Any dictionary that isn't `LIG` hits the `comp_XXX` fallback — which almost never exists — and autobuild crashes with:

```
KeyError: "block 'comp_XXX' does not exist"
```

## Fix

Add `get_comp_block_key(cif)`, which reads the restraint block from the document instead of guessing the TLC: it returns the first block (other than the `comp_list` header) that actually contains a `_chem_comp_atom` loop. The historical `comp_LIG`/`comp_XXX` names are retained as a fallback for unusual layouts. Used in all three call sites.

This is robust to any three-letter code with no configuration, and there's no CLI option that could have worked around it (no TLC argument exists).

## Testing

Verified against a 120-dataset CDK4CyclinD1 set:
- Block distribution: **116 `comp_DRG`** + **4 `comp_LIG`**.
- Before: the 116 `comp_DRG` datasets crashed in autobuild with the `comp_XXX` KeyError.
- After: all 120 resolve, and fragment mols build successfully (e.g. a `DRG` dataset → 39 atoms).
- The 4 `comp_LIG` datasets are unaffected (still resolve to `comp_LIG`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)