### PR TITLE
Add PANDDA_PROGRESS structured progress signal

### DIFF
--- a/pandda_gemmi/pandda/pandda.py
+++ b/pandda_gemmi/pandda/pandda.py
@@ -63,6 +63,12 @@ def pandda(args: PanDDAArgs):
     time_begin_process_datasets = time.time()
     console.start_process_shells()
     for j, dtag in enumerate(datasets_to_process):
+        # Structured progress signal for downstream automation that needs to
+        # track per-dataset progress without scraping log-format-dependent
+        # output. Matches the regex ^PANDDA_PROGRESS: dataset (\d+)/(\d+)$.
+        # flush=True ensures the line lands on the stream before Ray batches
+        # more output behind it.
+        print(f"PANDDA_PROGRESS: dataset {j + 1}/{len(datasets_to_process)}", flush=True)
         new_pandda_events, new_autobuilds = process_dataset(
             dtag,
             args,


### PR DESCRIPTION
Adds a one-line structured progress signal at the start of each per-dataset iteration in `pandda_gemmi/pandda/pandda.py`:

```
PANDDA_PROGRESS: dataset <j+1>/<N>
```

with `flush=True` so the line lands on the stream before Ray batches more output behind it. `j+1` is 1-indexed for human readability; `N` is `len(datasets_to_process)`.

## Motivation

Downstream automation (run wrappers, CI smoke tests, cloud-job orchestrators) wants a stable, structured progress signal it can rely on without scraping PanDDA's existing log lines. The existing log surface evolves between PanDDA versions, interleaves with Ray's own output, and isn't designed to be machine-parsed — so any regex over it is fragile, sometimes silently so.

A single contract symbol (`PANDDA_PROGRESS:` + a tiny grammar) is cheaper to maintain forever than a brittle regex that has to be re-validated on every release. Once added, runners can match:

```
^PANDDA_PROGRESS: dataset (\d+)/(\d+)$
```

…and rely on it indefinitely.

## What it changes

- 6 lines added to `pandda_gemmi/pandda/pandda.py` (1 line of code + 5 lines of comment explaining intent).
- No code paths altered; no flag introduced; no analysis behaviour changed.
- One additional `print()` per dataset in the main `for j, dtag in enumerate(datasets_to_process):` loop.

## Considered alternatives

- **Parsing existing log lines.** Rejected because PanDDA's organic log output varies across versions and interleaves with Ray's stdout, making a robust regex expensive to maintain. We'd rather pay for one contract symbol once.
- **Per-shell signal.** Considered, but the visible outer iteration in `pandda.py` is per-dataset; "shells" exist inside `process_dataset()` as a memory-scaling concept but aren't the natural progress granularity at this layer. If a future PanDDA version surfaces per-shell progress at the outer layer, a `PANDDA_PROGRESS: shell <i>/<N>` line can be added then under the same prefix.

## Context

Materia's PanDDA-on-Azure deployment ([apps/compounds/docs/proposal/PANDDA2_ON_AZURE.md](https://github.com/newcastleuniversity/materia/blob/main/apps/compounds/docs/proposal/PANDDA2_ON_AZURE.md)) and Reinspect's `AzureBatchRunner` ([github.com/martinemnoble1/pandda-inspect-api](https://github.com/martinemnoble1/pandda-inspect-api)) both want this signal for cloud-job monitoring. Wanted to bring the change canonically upstream rather than rely on the `mac-fixes` fork indefinitely, so other PanDDA consumers benefit too.